### PR TITLE
Adding Client Certificates For Authentication

### DIFF
--- a/demos/raytune-oai-MR-gRPC-demo.ipynb
+++ b/demos/raytune-oai-MR-gRPC-demo.ipynb
@@ -86,6 +86,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "1f1a5c1a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from codeflare_sdk import generate_cert\n",
+    "# Create required TLS cert and export the environment variables to enable TLS\n",
+    "generate_cert.generate_tls_cert(cluster_name, namespace)\n",
+    "generate_cert.export_env(cluster_name, namespace)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "62c30fb0-01fd-417b-811c-f97070f367b0",
    "metadata": {},
    "outputs": [],

--- a/demos/raytune-oai-demo-mlmd.ipynb
+++ b/demos/raytune-oai-demo-mlmd.ipynb
@@ -99,6 +99,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "4bb7f911",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from codeflare_sdk import generate_cert\n",
+    "# Create required TLS cert and export the environment variables to enable TLS\n",
+    "generate_cert.generate_tls_cert(cluster_name, namespace)\n",
+    "generate_cert.export_env(cluster_name, namespace)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "62c30fb0-01fd-417b-811c-f97070f367b0",
    "metadata": {},
    "outputs": [],

--- a/demos/raytune-oai-demo.ipynb
+++ b/demos/raytune-oai-demo.ipynb
@@ -100,6 +100,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "b589f722",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from codeflare_sdk import generate_cert\n",
+    "# Create required TLS cert and export the environment variables to enable TLS\n",
+    "generate_cert.generate_tls_cert(cluster_name, namespace)\n",
+    "generate_cert.export_env(cluster_name, namespace)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "878a059e-d267-4b3e-972f-cb3cf9557f64",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
# Adding Client Certificates For Authentication

## Description

This PR will do the following changes - 
- adds the code to generate client certificates for authentication
- resolves the time-out error faced while connecting to the ray cluster

### Type of change

- [x] Refactoring Code
- [ ] New feature

## How has this been tested?

- On Openshift-AI cluster, in Jupyter Notebook Enviroment

**Test Configuration**
* Kubernetes clusters tested on: Openshift-AI Cluster

## Checklist :dart:

- [X] Followed coding guidelines
- [X] Comments added
- [ ] Dependent changes merged
- [ ] Documentation updated
- [ ] Tests added or updated

## Additional information
With RHOAI 2.9, the client endpoint is secured and the Ray client has to authenticate using a client certificate. 

## References
- https://redhat-internal.slack.com/archives/C06C5MK3MT9/p1716449925243959?thread_ts=1716440753.568609&cid=C06C5MK3MT9
- https://github.com/project-codeflare/codeflare-sdk/blob/54e90f5b7900822ae534d885ff6e621eb0c9b638/demo-notebooks/guided-demos/2_basic_interactive.ipynb#L136-L141