### PR TITLE
Updating Readme to Use Correct Version of Protobuf

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -15,7 +15,7 @@ This code primarily focuses on optimizing machine learning models using RayTune.
 1. **Installation**: The code starts by installing the necessary dependencies using `pip`.
 2. **Authentication**: It sets up authentication for accessing the cluster. Replace the `TOKEN` and `SERVER` values with actual authentication tokens and server URLs.
 3. **Cluster Configuration**: Configures the Ray cluster with the desired parameters such as number of workers, CPU and memory allocation.
-4. **Cluster Deployment**: Brings up the Ray cluster using the configuration defined.
+4. **Cluster Deployment**: Brings up the Ray cluster using the configuration defined. While initializing the Ray cluster, you need to specify `protobuf` version `3.20.1` in the `runtime_env` parameter during Ray initialization. This ensures that the correct version of `protobuf` is used, avoiding the `RayTaskError` issues.
 5. **Hyperparameter Tuning & log Metadata**: Uses Ray Tune to perform hyperparameter tuning on a simple neural network model while concurrently logging metadata.
 6. **Model Deployment**: Saves the best model obtained from hyperparameter tuning in the ONNX format and uploads it to an S3 bucket.
 7. **REST API Integration**: Sets up details to access the deployed model through a REST API.

--- a/demos/README.md
+++ b/demos/README.md
@@ -15,7 +15,7 @@ This code primarily focuses on optimizing machine learning models using RayTune.
 1. **Installation**: The code starts by installing the necessary dependencies using `pip`.
 2. **Authentication**: It sets up authentication for accessing the cluster. Replace the `TOKEN` and `SERVER` values with actual authentication tokens and server URLs.
 3. **Cluster Configuration**: Configures the Ray cluster with the desired parameters such as number of workers, CPU and memory allocation.
-4. **Cluster Deployment**: Brings up the Ray cluster using the configuration defined. While initializing the Ray cluster, you need to specify `protobuf` version `3.20.1` in the `runtime_env` parameter during Ray initialization. This ensures that the correct version of `protobuf` is used, avoiding the `RayTaskError` issues.
+4. **Cluster Deployment**: Brings up the Ray cluster using the configuration defined.
 5. **Hyperparameter Tuning & log Metadata**: Uses Ray Tune to perform hyperparameter tuning on a simple neural network model while concurrently logging metadata.
 6. **Model Deployment**: Saves the best model obtained from hyperparameter tuning in the ONNX format and uploads it to an S3 bucket.
 7. **REST API Integration**: Sets up details to access the deployed model through a REST API.
@@ -68,4 +68,8 @@ kubectl apply -k config/samples/postgres
 
 By following these instructions, you can effectively leverage the provided code to discover the optimal model using RayTune and subsequently deploy and serve machine learning models using Ray and the CodeFlare SDK.
 
+## Troubleshooting 
+
+- **RayTaskError or TypeError stating "Descriptors cannot be created directly."** 
+This error indicates compatibility issues with the protobuf library version used in your project. While initializing the Ray cluster, you need to specify `protobuf` version `3.20.1` in the `runtime_env` parameter during Ray initialization. This ensures that the correct version of `protobuf` is used, avoiding the `RayTaskError` issues.
 


### PR DESCRIPTION
# Updating Readme to Use Correct Version of `protobuf`

## Description
This PR will do the following changes -
- updates the documentation to use correct version of `protobuf` library to avoid `RayTaskError` issues

## Type of change
- [ ] Refactoring Code
- [ ] New feature
- [x] Documentation Update

## How has this been tested?
Validated the version compatibility on Openshift-AI cluster using hpo-demos. 

## Test Configuration
- Kubernetes clusters tested on: Openshift-AI Cluster

Checklist 🎯
- [ ] Followed coding guidelines
- [ ] Comments added
- [ ] Dependent changes merged
- [X] Documentation updated
- [ ] Tests added or updated

## Additional information
- RayTaskError clearly states to downgrade the protobuf version
```bash
TypeError: Descriptors cannot be created directly.
If this call came from a _pb2.py file, your generated code is out of date and must be regenerated with protoc >= 3.19.0.
If you cannot immediately regenerate your protos, some other possible workarounds are:
 1. Downgrade the protobuf package to 3.20.x or lower.
 2. Set PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python (but this will use pure-Python parsing and will be much slower).
 3. More information: https://developers.google.com/protocol-buffers/docs/news/2022-05-06#python-updates 
```
- Known Issue of GitHub: https://github.com/ray-project/ray/issues/36417
- Another Reference: https://stackoverflow.com/questions/72441758/typeerror-descriptors-cannot-not-be-created-directly 